### PR TITLE
Fix LogLine request supporting empty requests

### DIFF
--- a/src/DataTransferObjects/LogLine.php
+++ b/src/DataTransferObjects/LogLine.php
@@ -36,7 +36,7 @@ class LogLine extends DataTransferObject implements LogLineInterface
     /**
      * Request data
      *
-     * @var string
+     * @var string|null
      */
     private $requestData;
 
@@ -53,14 +53,14 @@ class LogLine extends DataTransferObject implements LogLineInterface
      * @param string $clientIp Client ip
      * @param int $lineStatus Status
      * @param \DateTime $occurredAt Occurred timestamp
-     * @param string $requestData Request data
+     * @param string|null $requestData Request data
      * @param string|null $responseData Response data
      */
     public function __construct(
         string $clientIp,
         int $lineStatus,
         DateTime $occurredAt,
-        string $requestData,
+        ?string $requestData,
         ?string $responseData
     ) {
         $this->clientIp = $clientIp;
@@ -105,7 +105,7 @@ class LogLine extends DataTransferObject implements LogLineInterface
      *
      * @return string
      */
-    public function getRequestData(): string
+    public function getRequestData(): ?string
     {
         return $this->requestData;
     }

--- a/src/Services/LogLineFactory.php
+++ b/src/Services/LogLineFactory.php
@@ -26,12 +26,17 @@ final class LogLineFactory implements LogLineFactoryInterface
         RequestInterface $request,
         ?ResponseInterface $response
     ): LogLine {
+        $requestString = $this->getStreamContentTruncated($request->getBody());
+        $responseString = $response instanceof ResponseInterface
+            ? $this->getStreamContentTruncated($response->getBody())
+            : null;
+
         return new LogLine(
             $ipAddress,
             0,
             $now,
-            $this->getStreamContentTruncated($request->getBody()),
-            $response instanceof ResponseInterface ? $this->getStreamContentTruncated($response->getBody()) : null
+            $requestString ?: null,
+            $responseString ?: null
         );
     }
 

--- a/src/Services/LogLineFactory.php
+++ b/src/Services/LogLineFactory.php
@@ -5,6 +5,7 @@ namespace LoyaltyCorp\Auditing\Services;
 
 use DateTime;
 use LoyaltyCorp\Auditing\DataTransferObjects\LogLine;
+use LoyaltyCorp\Auditing\Interfaces\DataTransferObjects\LogLineInterface;
 use LoyaltyCorp\Auditing\Interfaces\Services\LogLineFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -33,7 +34,7 @@ final class LogLineFactory implements LogLineFactoryInterface
 
         return new LogLine(
             $ipAddress,
-            0,
+            LogLineInterface::LINE_STATUS_NOT_INDEXED,
             $now,
             $requestString ?: null,
             $responseString ?: null

--- a/tests/Services/LogLineFactoryTest.php
+++ b/tests/Services/LogLineFactoryTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 namespace Tests\LoyaltyCorp\Auditing\Services;
 
 use EoneoPay\Utils\DateTime;
+use GuzzleHttp\Psr7\BufferStream;
 use LoyaltyCorp\Auditing\Services\LogLineFactory;
 use Tests\LoyaltyCorp\Auditing\Stubs\Services\LogLineFactory\RequestStub;
 use Tests\LoyaltyCorp\Auditing\Stubs\Services\LogLineFactory\ResponseStub;
 use Tests\LoyaltyCorp\Auditing\TestCase;
+use Zend\Diactoros\Request;
 
 /**
  * @covers \LoyaltyCorp\Auditing\Services\LogLineFactory
@@ -34,6 +36,32 @@ class LogLineFactoryTest extends TestCase
 
         self::assertSame('127.0.0.1', $dto->getClientIp());
         self::assertSame('2019-05-05 12:12:12', $dto->getOccurredAt()->format('Y-m-d H:i:s'));
+        self::assertIsString($dto->getResponseData());
+    }
+
+    /**
+     * Test creating a log line DTO using the factory
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     */
+    public function testCreationEmptyRequestBecomesNull(): void
+    {
+        $request = new Request(null, null, new BufferStream());
+
+        $logLineFactory = $this->getInstance();
+
+        $dto = $logLineFactory->create(
+            '127.0.0.1',
+            new DateTime('2019-05-05 12:12:12'),
+            $request,
+            new ResponseStub()
+        );
+
+        self::assertSame('127.0.0.1', $dto->getClientIp());
+        self::assertSame('2019-05-05 12:12:12', $dto->getOccurredAt()->format('Y-m-d H:i:s'));
+        self::assertNull($dto->getRequestData());
         self::assertIsString($dto->getResponseData());
     }
 


### PR DESCRIPTION
DynamoDB does not support empty strings.

```
{"message":"Exception caught: Marshaling error: empty strings are invalid.","context":{"file":"/var/www/vendor/aws/aws-sdk-php/src/DynamoDb/Marshaler.php","line":322},"level":250,"level_name":"NOTICE","channel":"Application","datetime":"2019-06-21T03:23:15+00:00","extra":{"url":"/?XDEBUG_SESSION_START=123","ip":"172.19.0.1","http_method":"GET","server":"api","referrer":null,"memory_usage":"8 MB","memory_peak_usage":"8 MB","file":"/var/www/vendor/loyaltycorp/auditing/src/Bridge/Laravel/Http/Middlewares/AuditMiddleware.php","line":110,"class":"LoyaltyCorp\\Auditing\\Bridge\\Laravel\\Http\\Middlewares\\AuditMiddleware","function":"callHttpLogger"}}
```