### PR TITLE
PYMT-938 Log full request and response instead of their body.

### DIFF
--- a/tests/Services/LogLineFactoryTest.php
+++ b/tests/Services/LogLineFactoryTest.php
@@ -40,17 +40,42 @@ class LogLineFactoryTest extends TestCase
     }
 
     /**
-     * Test creating a log line DTO using the factory
+     * Test creating a log line DTO using the factory with no response.
      *
      * @return void
      *
      * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      */
-    public function testCreationEmptyRequestBecomesNull(): void
+    public function testCreationWithNoResponse(): void
+    {
+        $logLineFactory = $this->getInstance();
+
+        $dto = $logLineFactory->create(
+            '127.0.0.1',
+            new DateTime('2019-05-05 12:12:12'),
+            new RequestStub(),
+            null
+        );
+
+        self::assertSame('127.0.0.1', $dto->getClientIp());
+        self::assertSame('2019-05-05 12:12:12', $dto->getOccurredAt()->format('Y-m-d H:i:s'));
+        self::assertNull($dto->getResponseData());
+    }
+
+    /**
+     * Test creating a log line DTO using the factory with empty request.
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     */
+    public function testCreationEmptyRequestReturnsExpectedRequestString(): void
     {
         $request = new Request(null, null, new BufferStream());
-
         $logLineFactory = $this->getInstance();
+        $expectedRequest = <<<EOF
+GET / HTTP/1.1\r\nHost: \r\n\r\n
+EOF;
 
         $dto = $logLineFactory->create(
             '127.0.0.1',
@@ -61,18 +86,18 @@ class LogLineFactoryTest extends TestCase
 
         self::assertSame('127.0.0.1', $dto->getClientIp());
         self::assertSame('2019-05-05 12:12:12', $dto->getOccurredAt()->format('Y-m-d H:i:s'));
-        self::assertNull($dto->getRequestData());
+        self::assertEquals($expectedRequest, $dto->getRequestData());
         self::assertIsString($dto->getResponseData());
     }
 
     /**
-     * Test the truncating of request/response body
+     * Test the truncating of message
      *
      * @return void
      *
      * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      */
-    public function testCreationTruncatesBody(): void
+    public function testCreationTruncatesMessage(): void
     {
         $logLineFactory = $this->getInstance();
 

--- a/tests/Stubs/Services/LogLineFactory/RequestStub.php
+++ b/tests/Stubs/Services/LogLineFactory/RequestStub.php
@@ -6,6 +6,7 @@ namespace Tests\LoyaltyCorp\Auditing\Stubs\Services\LogLineFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
+use Zend\Diactoros\Uri;
 
 /**
  * @coversNothing
@@ -55,6 +56,7 @@ class RequestStub implements RequestInterface
      */
     public function getHeaders()
     {
+        return ['key' => ['value']];
     }
 
     /**
@@ -83,6 +85,7 @@ class RequestStub implements RequestInterface
      */
     public function getUri()
     {
+        return new Uri('http::/localhost');
     }
 
     /**

--- a/tests/Stubs/Services/LogLineFactory/ResponseStub.php
+++ b/tests/Stubs/Services/LogLineFactory/ResponseStub.php
@@ -54,6 +54,7 @@ class ResponseStub implements ResponseInterface
      */
     public function getHeaders()
     {
+        return ['key' => ['value']];
     }
 
     /**

--- a/tests/Stubs/Services/LogLineFactory/StreamStub.php
+++ b/tests/Stubs/Services/LogLineFactory/StreamStub.php
@@ -33,7 +33,7 @@ class StreamStub implements StreamInterface
      */
     public function __toString()
     {
-        return '';
+        return $this->getContents();
     }
 
     /**
@@ -62,7 +62,11 @@ class StreamStub implements StreamInterface
      */
     public function getContents()
     {
-        return '';
+        return \str_pad(
+            '',
+            $this->contentSize,
+            '0'
+        );
     }
 
     /**


### PR DESCRIPTION
The auditing system only writes out the request and response bodies, not the full request and response as strings.

`LogLineFactory` now uses Guzzle's `str()` method to convert the entire request and response object to string and then truncate the resultant string to `MAX_CONTENT_BYTES` length.

Ticket: [https://loyaltycorp.atlassian.net/browse/PYMT-938](https://loyaltycorp.atlassian.net/browse/PYMT-938)