### PR TITLE
PYMT-1627: Use proxy IP for logging

### DIFF
--- a/src/Bridge/Laravel/Http/Middlewares/AuditMiddleware.php
+++ b/src/Bridge/Laravel/Http/Middlewares/AuditMiddleware.php
@@ -178,6 +178,7 @@ class AuditMiddleware
             $dateTime,
             $request->header('X-Forwarded-For') ?? $request->ip() ?? '',
             $psrRequest,
-            $psrResponse);
+            $psrResponse
+        );
     }
 }

--- a/src/Bridge/Laravel/Http/Middlewares/AuditMiddleware.php
+++ b/src/Bridge/Laravel/Http/Middlewares/AuditMiddleware.php
@@ -174,6 +174,10 @@ class AuditMiddleware
             $psrResponse = $response;
         }
 
-        $this->callHttpLogger($dateTime, $request->ip() ?? '', $psrRequest, $psrResponse);
+        $this->callHttpLogger(
+            $dateTime,
+            $request->header('X-Forwarded-For') ?? $request->ip() ?? '',
+            $psrRequest,
+            $psrResponse);
     }
 }

--- a/src/Bridge/Laravel/Http/Middlewares/AuditMiddleware.php
+++ b/src/Bridge/Laravel/Http/Middlewares/AuditMiddleware.php
@@ -174,9 +174,12 @@ class AuditMiddleware
             $psrResponse = $response;
         }
 
+        /** @var string $ipAddress Only one string is ever returned, see testProxyIpPassedToHttpLogger */
+        $ipAddress = $request->header('X-Forwarded-For') ?? $request->ip() ?? '';
+
         $this->callHttpLogger(
             $dateTime,
-            $request->header('X-Forwarded-For') ?? $request->ip() ?? '',
+            $ipAddress,
             $psrRequest,
             $psrResponse
         );

--- a/tests/Bridge/Laravel/Http/Middlewares/AuditMiddlewareTest.php
+++ b/tests/Bridge/Laravel/Http/Middlewares/AuditMiddlewareTest.php
@@ -273,17 +273,20 @@ class AuditMiddlewareTest extends TestCase
     /**
      * Get symfony request
      *
+     * @param string[] $headers Optional list of additional headers
+     *
      * @return \Illuminate\Http\Request
      */
-    private function getRequest(): Request
+    private function getRequest(array $headers = []): Request
     {
+        $headers = \array_merge(['HTTP_HOST' => 'loyaltycorp.com.au', 'REMOTE_ADDR' => '127.0.0.1'], $headers);
         return new Request(
             ['query' => 'value'],
             ['request' => 'value'],
             [],
             [],
             [],
-            ['HTTP_HOST' => 'loyaltycorp.com.au', 'REMOTE_ADDR' => '127.0.0.1'],
+            $headers,
             'Content'
         );
     }

--- a/tests/Bridge/Laravel/Http/Middlewares/AuditMiddlewareTest.php
+++ b/tests/Bridge/Laravel/Http/Middlewares/AuditMiddlewareTest.php
@@ -264,7 +264,7 @@ class AuditMiddlewareTest extends TestCase
         $middleware = $this->getMiddleware($httpLogger);
 
         $middleware->handle(
-            $this->getRequest(['HTTP_X-Forwarded-For' => '127.2.3.4']),
+            $this->getRequest(['HTTP_X-Forwarded-For' => ['127.2.3.4', '127.5.6.7']]),
             static function (): Response {
                 return new Response('OK');
             }
@@ -299,7 +299,7 @@ class AuditMiddlewareTest extends TestCase
     /**
      * Get symfony request
      *
-     * @param string[] $headers Optional list of additional headers
+     * @param string[][] $headers Optional list of additional headers
      *
      * @return \Illuminate\Http\Request
      */

--- a/tests/Bridge/Laravel/Http/Middlewares/AuditMiddlewareTest.php
+++ b/tests/Bridge/Laravel/Http/Middlewares/AuditMiddlewareTest.php
@@ -252,6 +252,32 @@ class AuditMiddlewareTest extends TestCase
     }
 
     /**
+     * Test if middleware logs the forwarding proxy address if it is available.
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     */
+    public function testProxyIpPassedToHttpLogger(): void
+    {
+        $httpLogger = new HttpLoggerStub();
+        $middleware = $this->getMiddleware($httpLogger);
+
+        $middleware->handle(
+            $this->getRequest(['HTTP_X-Forwarded-For' => '127.2.3.4']),
+            static function (): Response {
+                return new Response('OK');
+            }
+        );
+
+        self::assertInstanceOf(RequestInterface::class, $httpLogger->getRequest());
+        self::assertInstanceOf(ResponseInterface::class, $httpLogger->getResponse());
+        self::assertSame('127.2.3.4', $httpLogger->getIpAddress());
+        self::assertSame('loyaltycorp.com.au', $httpLogger->getRequest()->getUri()->getHost());
+        self::assertSame('OK', (string)$httpLogger->getResponse()->getBody());
+    }
+
+    /**
      * Get instance of middleware
      *
      * @param \LoyaltyCorp\Auditing\Bridge\Laravel\Services\Interfaces\HttpLoggerInterface|null $httpLogger


### PR DESCRIPTION
Ticket: https://eonx.atlassian.net/browse/PYMT-1627

This uses the proxy IP (if set) when logging requests via the Audit middleware.

This ticket requires an additional piece of work for integrating the change in Subscriptions.