### PR TITLE
SUBS-60: Provider aware elastic search indexing

### DIFF
--- a/src/Services/SearchLogWriter.php
+++ b/src/Services/SearchLogWriter.php
@@ -34,8 +34,13 @@ final class SearchLogWriter implements SearchLogWriterInterface
         $documents = [];
 
         foreach ($logLines as $logLine) {
+            $index = 'http-requests';
+            if (empty($logLine['providerId']) === false) {
+                $index = \sprintf('http-requests_%s', $logLine['providerId']);
+                unset($logLine['providerId']);
+            }
             $documents[] = new DocumentUpdate(
-                'http-requests',
+                $index,
                 $logLine['requestId'],
                 $logLine
             );

--- a/src/Services/SearchLogWriter.php
+++ b/src/Services/SearchLogWriter.php
@@ -35,7 +35,10 @@ final class SearchLogWriter implements SearchLogWriterInterface
 
         foreach ($logLines as $logLine) {
             $index = 'http-requests';
-            if (empty($logLine['providerId']) === false) {
+            if (\array_key_exists('providerId', $logLine) === true &&
+                \is_string($logLine['providerId']) === true &&
+                \strlen($logLine['providerId']) !== 0
+            ) {
                 $index = \sprintf('http-requests_%s', \strtolower($logLine['providerId']));
                 unset($logLine['providerId']);
             }

--- a/src/Services/SearchLogWriter.php
+++ b/src/Services/SearchLogWriter.php
@@ -36,7 +36,7 @@ final class SearchLogWriter implements SearchLogWriterInterface
         foreach ($logLines as $logLine) {
             $index = 'http-requests';
             if (empty($logLine['providerId']) === false) {
-                $index = \sprintf('http-requests_%s', $logLine['providerId']);
+                $index = \sprintf('http-requests_%s', \strtolower($logLine['providerId']));
                 unset($logLine['providerId']);
             }
             $documents[] = new DocumentUpdate(

--- a/tests/Services/SearchLogWriterTest.php
+++ b/tests/Services/SearchLogWriterTest.php
@@ -59,8 +59,6 @@ class SearchLogWriterTest extends TestCase
      * Test bulk write to search log successfully for Provider Aware logs.
      *
      * @return void
-     *
-     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      */
     public function testBulkWriteProviderAware(): void
     {
@@ -80,7 +78,7 @@ class SearchLogWriterTest extends TestCase
 
         $expected = [
             new DocumentUpdate(
-                'http-requests_PROV--ABC123',
+                'http-requests_prov--abc123',
                 'ReqId-Test-1111',
                 [
                     'clientIp' => '127.0.01',

--- a/tests/Services/SearchLogWriterTest.php
+++ b/tests/Services/SearchLogWriterTest.php
@@ -54,4 +54,47 @@ class SearchLogWriterTest extends TestCase
 
         self::assertEquals([$expected], $searchClient->getUpdates());
     }
+
+    /**
+     * Test bulk write to search log successfully for Provider Aware logs.
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     */
+    public function testBulkWriteProviderAware(): void
+    {
+        $searchClient = new SearchClientStub();
+        $searchLogWriter = new SearchLogWriter($searchClient);
+        $occurredAt = '2018-03-22 13:45:56';
+
+        $line = [
+            'clientIp' => '127.0.01',
+            'lineStatus' => 1,
+            'occurredAt' => $occurredAt,
+            'providerId' => 'PROV--ABC123',
+            'requestData' => '{"help": "me"}',
+            'requestId' => 'ReqId-Test-1111',
+            'responseData' => '{"abc": [1,2,3,4,5,7]}'
+        ];
+
+        $expected = [
+            new DocumentUpdate(
+                'http-requests_PROV--ABC123',
+                'ReqId-Test-1111',
+                [
+                    'clientIp' => '127.0.01',
+                    'lineStatus' => 1,
+                    'occurredAt' => $occurredAt,
+                    'requestData' => '{"help": "me"}',
+                    'requestId' => 'ReqId-Test-1111',
+                    'responseData' => '{"abc": [1,2,3,4,5,7]}'
+                ]
+            )
+        ];
+
+        $searchLogWriter->bulkWrite([$line]);
+
+        self::assertEquals([$expected], $searchClient->getUpdates());
+    }
 }


### PR DESCRIPTION
Ticket: https://eonx.atlassian.net/browse/SUBS-60

This makes all auditing logs go into their own provider specific indexes, if a provider ID is set.